### PR TITLE
add common restart command (so can be called via mqtt)

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=OXRS-IO-WT32-ESP32-LIB
-version=1.0.0
+version=1.1.0
 author=OXRS Core Team
 maintainer=moinmoin-sh <moinmoin-sh@t-online.de>
 sentence=WT32-SC01 library for Open eXtensible Rack System projects

--- a/src/OXRS_WT32.cpp
+++ b/src/OXRS_WT32.cpp
@@ -153,6 +153,11 @@ void _getCommandSchemaJson(JsonVariant json)
   {
     _mergeJson(properties, _fwCommandSchema.as<JsonVariant>());
   }
+
+  // Restart command
+  JsonObject restart = properties.createNestedObject("restart");
+  restart["title"] = "Restart";
+  restart["type"] = "boolean";
 }
 
 /* API callbacks */
@@ -229,6 +234,12 @@ void _mqttConfig(JsonVariant json)
 
 void _mqttCommand(JsonVariant json)
 {
+  // Core restart command
+  if (json.containsKey("restart") && json["restart"].as<bool>())
+  {
+    ESP.restart();
+  }
+
   // Pass on to the firmware callback
   if (_onCommand)
   {


### PR DESCRIPTION
Requested by @hazymat

Allows restarting by publishing `{"restart":true}` to `cmnd/`