### PR TITLE
set a 5 min timeout if no activity in the captive portal, so the devi…

### DIFF
--- a/src/OXRS_WT32.cpp
+++ b/src/OXRS_WT32.cpp
@@ -447,6 +447,11 @@ void OXRS_WT32::_initialiseNetwork(byte * mac)
   // Ensure we are in the correct WiFi mode
   WiFi.mode(WIFI_STA);
 
+  // If captive portal is launched and nothing happens for a while then
+  // exit autoConnect() and continue loading the firmware - if the user
+  // needs to retry they can restart the device via the settings page
+  wm.setConfigPortalTimeout(WM_CONFIG_PORTAL_TIMEOUT_S);
+
   // Connect using saved creds, or start captive portal if none found
   // NOTE: Blocks until connected or the portal is closed
   WiFiManager wm;

--- a/src/OXRS_WT32.cpp
+++ b/src/OXRS_WT32.cpp
@@ -451,9 +451,9 @@ void OXRS_WT32::_initialiseNetwork(byte * mac)
   // to handle WiFi connection and credential persistence etc.
   WiFiManager wm;
 
-  // If captive portal is launched and nothing happens for a while then
-  // exit autoConnect() and continue loading the firmware - if the user
-  // needs to retry they can restart the device via the settings page
+  // If the captive portal is launched and nothing happens for a while then
+  // reboot - this helps if we come online before an AP (e.g. power outage)
+  // and prevents us sitting in captive portal mode indefinitely
   wm.setConfigPortalTimeout(WM_CONFIG_PORTAL_TIMEOUT_S);
 
   // Connect using saved creds, or start captive portal if none found

--- a/src/OXRS_WT32.cpp
+++ b/src/OXRS_WT32.cpp
@@ -447,6 +447,10 @@ void OXRS_WT32::_initialiseNetwork(byte * mac)
   // Ensure we are in the correct WiFi mode
   WiFi.mode(WIFI_STA);
 
+  // We use WifiManager library from https://github.com/tzapu/WiFiManager
+  // to handle WiFi connection and credential persistence etc.
+  WiFiManager wm;
+
   // If captive portal is launched and nothing happens for a while then
   // exit autoConnect() and continue loading the firmware - if the user
   // needs to retry they can restart the device via the settings page
@@ -454,7 +458,6 @@ void OXRS_WT32::_initialiseNetwork(byte * mac)
 
   // Connect using saved creds, or start captive portal if none found
   // NOTE: Blocks until connected or the portal is closed
-  WiFiManager wm;
   if (!wm.autoConnect("OXRS_WiFi", "superhouse"))
   {
     _logger.println(F("[wt32] failed to connect to wifi access point, rebooting"));

--- a/src/OXRS_WT32.cpp
+++ b/src/OXRS_WT32.cpp
@@ -457,8 +457,8 @@ void OXRS_WT32::_initialiseNetwork(byte * mac)
   WiFiManager wm;
   if (!wm.autoConnect("OXRS_WiFi", "superhouse"))
   {
-    _logger.println(F("[wt32] failed to connect to wifi acces point"));
-    return;
+    _logger.println(F("[wt32] failed to connect to wifi access point, rebooting"));
+    ESP.restart();
   }
   
   IPAddress ipAddress = WiFi.localIP();

--- a/src/OXRS_WT32.h
+++ b/src/OXRS_WT32.h
@@ -8,16 +8,19 @@
 #include <OXRS_MQTT.h>    // For MQTT pub/sub
 #include <OXRS_API.h>     // For REST API
 
+// WifiManager
+#define WM_CONFIG_PORTAL_TIMEOUT_S  300
+
 // Ethernet
-#define DHCP_TIMEOUT_MS           15000
-#define DHCP_RESPONSE_TIMEOUT_MS  4000
+#define DHCP_TIMEOUT_MS             15000
+#define DHCP_RESPONSE_TIMEOUT_MS    4000
 
 // REST API
-#define REST_API_PORT             80
+#define REST_API_PORT               80
 
 // Screen dimensions
-#define WT32_SCREEN_WIDTH         320
-#define WT32_SCREEN_HEIGHT        480
+#define WT32_SCREEN_WIDTH           320
+#define WT32_SCREEN_HEIGHT          480
 
 // Enum for the different connection states
 enum connectionState_t { CONNECTED_NONE, CONNECTED_IP, CONNECTED_MQTT };


### PR DESCRIPTION
…ce doesn't remain locked if booted before the WiFi network comes up

This is untested (it is late on Sat night) but wondering if this looks like a reasonable solution?

On boot, if it can't connect to an existing SSID, it will enter captive portal mode. Currently it sits there waiting till someone connects and configures a network. This is not good if your WiFi AP is restarting and takes longer than the WT32 boot sequence. 

This change should mean that after 5 mins the device exits the captive portal and shows an empty screen. From there you can manually restart the device from the settings page.

Perhaps we should just reboot if `.autoConnect()` exits without connecting to a network? Wasn't sure if this is a good look, the device would reboot every 5 mins if left untouched in this scenario...  