### PR TITLE
get version from main instead buildflag

### DIFF
--- a/src/OXRS_WT32.cpp
+++ b/src/OXRS_WT32.cpp
@@ -48,7 +48,7 @@ jsonCallback _onConfig;
 jsonCallback _onCommand;
 
 // local variables
-char _fwVersion[40] = "";
+char _fwVersion[40] = "<No Version>";
 
 /* JSON helpers */
 void _mergeJson(JsonVariant dst, JsonVariantConst src)

--- a/src/OXRS_WT32.cpp
+++ b/src/OXRS_WT32.cpp
@@ -47,6 +47,9 @@ DynamicJsonDocument _fwCommandSchema(JSON_CONFIG_MAX_SIZE);
 jsonCallback _onConfig;
 jsonCallback _onCommand;
 
+// local variables
+char _fwVersion[40] = "";
+
 /* JSON helpers */
 void _mergeJson(JsonVariant dst, JsonVariantConst src)
 {
@@ -78,15 +81,7 @@ void _getFirmwareJson(JsonVariant json)
   firmware["name"] = FW_NAME;
   firmware["shortName"] = FW_SHORT_NAME;
   firmware["maker"] = FW_MAKER;
-#if defined(FW_VERSION)
-  firmware["version"] = STRINGIFY(FW_VERSION);
-#elif defined(BUILD_TIMESTAMP)
-  char buffer[40];
-  time_t rawtime = BUILD_TIMESTAMP;
-  struct tm ts = *localtime(&rawtime);
-  strftime(buffer, sizeof(buffer), "Build: %Y-%m-%d %H:%M:%S %Z", &ts);
-  firmware["version"] = buffer;
-#endif
+  firmware["version"] = _fwVersion;
 #if defined(FW_HARDWARE)
   firmware["hardware"] = STRINGIFY(FW_HARDWARE);
 #endif
@@ -594,4 +589,9 @@ void OXRS_WT32::getMQTTTopicTxt(char *buffer)
     strcpy(buffer, "");
     strncat(buffer, topic, 39);
   }
+}
+
+void OXRS_WT32::setFwVersion(const char *version)
+{
+  strncpy(_fwVersion, version, sizeof(_fwVersion));
 }

--- a/src/OXRS_WT32.h
+++ b/src/OXRS_WT32.h
@@ -35,6 +35,8 @@ public:
   void begin(jsonCallback config, jsonCallback command);
   void loop(void);
 
+  // Firmware sets the value (string) of "version":<value> in adopt payload
+  // depending on buildflags that are evaluated in main as single source
   void setFwVersion(const char *version);
 
   // Firmware can define the config/commands it supports - for device discovery and adoption

--- a/src/OXRS_WT32.h
+++ b/src/OXRS_WT32.h
@@ -18,10 +18,6 @@
 // REST API
 #define REST_API_PORT               80
 
-// Screen dimensions
-#define WT32_SCREEN_WIDTH           320
-#define WT32_SCREEN_HEIGHT          480
-
 // Enum for the different connection states
 enum connectionState_t { CONNECTED_NONE, CONNECTED_IP, CONNECTED_MQTT };
 
@@ -38,6 +34,8 @@ public:
 
   void begin(jsonCallback config, jsonCallback command);
   void loop(void);
+
+  void setFwVersion(const char *version);
 
   // Firmware can define the config/commands it supports - for device discovery and adoption
   void setConfigSchema(JsonVariant json);


### PR DESCRIPTION
I have an issue with the build timestamp in the FW. 
I set the UNIX timestamp at compile time with a buildflag within platformio.ini. This in turn causes a full build of the FW every time I start a new build, even if only a single file was modified. That takes > 7 minutes on my laptop - boring!
I found a way with an adiitional .py script to set a buildflag for a single file only which solves the issue.
To have a single file in the project that generates the build timestamp , (or better: the suitable version string) I made the main.cpp the creator and send the version string down to `wt32.setFwVersion()` before `wt32.begin()`.
