### PR TITLE
add ESP32S3 internal chip temperature

### DIFF
--- a/src/OXRS_WT32.cpp
+++ b/src/OXRS_WT32.cpp
@@ -172,7 +172,13 @@ void _getConfigSchemaJson(JsonVariant json)
   }
 
   // sensor config only if ESP is S3 or SHT20 found
-  if (strcmp(ESP.getChipModel(), "ESP32-S3") == 0 || _sht20Found)
+#if defined(CONFIG_IDF_TARGET_ESP32S3)
+  bool _s3Detected = true;
+#else
+  bool _s3Detected = false;
+#endif
+
+  if (_s3Detected || _sht20Found)
   {
     JsonObject climateUpdateSeconds = properties.createNestedObject("climateUpdateSeconds");
     climateUpdateSeconds["title"] = "Sensor Update Interval (seconds)";

--- a/src/OXRS_WT32.cpp
+++ b/src/OXRS_WT32.cpp
@@ -171,8 +171,8 @@ void _getConfigSchemaJson(JsonVariant json)
     _mergeJson(properties, _fwConfigSchema.as<JsonVariant>());
   }
 
-  // sensor config
-#if defined(CONFIG_IDF_TARGET_ESP32S3)
+  // sensor config only if ESP is S3 or SHT20 found
+  if (strcmp(ESP.getChipModel(), "ESP32-S3") == 0 || _sht20Found)
   {
     JsonObject climateUpdateSeconds = properties.createNestedObject("climateUpdateSeconds");
     climateUpdateSeconds["title"] = "Sensor Update Interval (seconds)";
@@ -181,7 +181,6 @@ void _getConfigSchemaJson(JsonVariant json)
     climateUpdateSeconds["minimum"] = 0;
     climateUpdateSeconds["maximum"] = 86400;
   }
-#endif
 }
 
 void _getCommandSchemaJson(JsonVariant json)

--- a/src/OXRS_WT32.h
+++ b/src/OXRS_WT32.h
@@ -78,8 +78,6 @@ private:
   void _initialiseClimateSensor(void);
   void _updateClimateSensor(void);
 
-  void _initialiseESP32TempSensor(void);
-
   boolean _isNetworkConnected(void);
 
   uint32_t _lastClimateUpdate = 0L;

--- a/src/OXRS_WT32.h
+++ b/src/OXRS_WT32.h
@@ -78,6 +78,8 @@ private:
   void _initialiseClimateSensor(void);
   void _updateClimateSensor(void);
 
+  void _initialiseESP32TempSensor(void);
+
   boolean _isNetworkConnected(void);
 
   uint32_t _lastClimateUpdate = 0L;


### PR DESCRIPTION
The ESP32S3 chip has got an internal temperatur sensor. 
I propose to add this information to the` /tele` payload for diagnostic purpose only  because the chip temperature is clearly of no use to report ambient temperature values but this information could give an idea about the internal temperatur when the panel is mounted on the wall.